### PR TITLE
Update aws-global-inventory.md. Use `awscc` instead of `aws`

### DIFF
--- a/docs/cookbooks/aws/aws-global-inventory.md
+++ b/docs/cookbooks/aws/aws-global-inventory.md
@@ -27,7 +27,7 @@ StackQL implements a SQL engine which can process multiple queries asynchronousl
 
 ```sql
 SELECT region, COUNT(*) as num_functions
-FROM aws.lambda.functions
+FROM awscc.lambda.functions
 WHERE region IN (
 	'us-east-1','us-east-2','us-west-1','us-west-2',
 	'ap-south-1','ap-northeast-3','ap-northeast-2',


### PR DESCRIPTION
It seems like that Lambda is only available in [`awscc`](https://awscc.stackql.io/providers/awscc/) instead in `aws`.