### PR TITLE
Document MCP server integration in StackQL

### DIFF
--- a/docs/command-line-usage/mcp.md
+++ b/docs/command-line-usage/mcp.md
@@ -1,0 +1,290 @@
+---
+title: mcp
+hide_title: false
+hide_table_of_contents: false
+keywords:
+  - stackql
+  - mcp
+  - model context protocol
+  - infrastructure-as-code
+  - configuration-as-data
+  - cloud inventory
+description: Query and Deploy Cloud Infrastructure and Resources using SQL via MCP
+image: "/img/stackql-featured-image.png"
+---
+
+Command used to launch StackQL as a Model Context Protocol (MCP) server, enabling AI agents and assistants to interact with cloud infrastructure using StackQL's query capabilities.
+
+* * *
+
+## What is MCP?
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open protocol that standardizes how AI applications interact with external data sources and tools. By running StackQL as an MCP server, you can enable AI agents (like Claude, ChatGPT, and others) to query and manage cloud infrastructure across multiple providers using natural language.
+
+* * *
+
+### Syntax
+
+`stackql mcp [flags]`
+
+* * *
+
+### Deployment Modes
+
+StackQL's MCP server can be deployed in three different configurations to suit various architectural requirements:
+
+#### 1. Standalone MCP Server
+
+Run StackQL as a dedicated MCP server on a specified port.
+
+```bash
+stackql mcp \
+  --mcp.server.type=http \
+  --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9912"}}'
+```
+
+**Use case:** When you only need MCP protocol access and don't require PostgreSQL wire protocol compatibility.
+
+#### 2. MCP + PostgreSQL Server (In-Memory)
+
+Run both MCP and PostgreSQL servers simultaneously with in-memory communication between them.
+
+```bash
+stackql srv \
+  --mcp.server.type=http \
+  --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9912"}}' \
+  --pgsrv.port 5665
+```
+
+**Use case:** When you need both MCP protocol access for AI agents and PostgreSQL wire protocol for traditional database clients, with maximum performance through in-memory communication.
+
+#### 3. MCP + PostgreSQL Server (Reverse Proxy)
+
+Run both servers with TCP-based communication, supporting distributed deployments and TLS encryption.
+
+```bash
+stackql srv \
+  --mcp.server.type=reverse_proxy \
+  --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9004"}, "backend": {"dsn": "postgres://stackql:stackql@127.0.0.1:5446?default_query_exec_mode=simple_protocol"}}' \
+  --pgsrv.port 5446
+```
+
+**With TLS encryption:**
+
+```bash
+stackql srv \
+  --mcp.server.type=reverse_proxy \
+  --mcp.config '{"server": {"tls_cert_file": "/path/to/mtls/credentials/pg_server_cert.pem", "tls_key_file": "/path/to/mtls/credentials/pg_server_key.pem", "transport": "http", "address": "127.0.0.1:9004"}, "backend": {"dsn": "postgres://stackql:stackql@127.0.0.1:5446?default_query_exec_mode=simple_protocol"}}' \
+  --pgsrv.port 5446
+```
+
+**Use case:** When you need to separate MCP and PostgreSQL workloads across different processes or hosts, or when you require TLS encryption for the MCP endpoint.
+
+* * *
+
+### Configuration Options
+
+#### MCP Server Type
+
+| Type | Description |
+|--|--|
+|`http`|Direct HTTP server mode - MCP requests are handled directly by StackQL|
+|`reverse_proxy`|Reverse proxy mode - MCP requests are forwarded to a PostgreSQL backend via DSN|
+
+#### MCP Configuration Object
+
+The `--mcp.config` flag accepts a JSON object with the following structure:
+
+##### Server Configuration
+
+| Field | Description | Required |
+|--|--|--|
+|`server.transport`|Transport protocol (currently only `http` is supported)|Yes|
+|`server.address`|Address and port to bind the MCP server (e.g., `127.0.0.1:9912`)|Yes|
+|`server.tls_cert_file`|Path to TLS certificate file for HTTPS|No|
+|`server.tls_key_file`|Path to TLS private key file for HTTPS|No|
+
+##### Backend Configuration (Reverse Proxy Mode Only)
+
+| Field | Description | Required |
+|--|--|--|
+|`backend.dsn`|PostgreSQL connection string for the backend StackQL server|Yes (for reverse_proxy)|
+
+:::info
+
+The backend DSN should include the `default_query_exec_mode=simple_protocol` parameter for optimal compatibility.
+
+:::
+
+* * *
+
+### Available MCP Tools
+
+When running as an MCP server, StackQL exposes the following tools that AI agents can invoke:
+
+| Tool | Description | Parameters |
+|--|--|--|
+|`greet`|Simple greeting tool for testing connectivity|`name` (string)|
+|`list_providers`|List all available StackQL providers|None|
+|`list_services`|List services available in a provider|`provider` (string)|
+|`list_resources`|List resources in a provider service|`provider` (string), `service` (string)|
+|`list_methods`|List methods available for a resource|`provider` (string), `service` (string), `resource` (string)|
+|`query_v2`|Execute a StackQL query|`sql` (string)|
+
+* * *
+
+### Flags
+
+| Flag | Description |
+|--|--|
+|`--mcp.server.type`|MCP server type: `http` or `reverse_proxy`|
+|`--mcp.config`|JSON configuration object for the MCP server|
+|`-H,--help`|Print help information|
+|`-v,--verbose`|Run in verbose mode with additional output|
+
+&nbsp;
+&nbsp;
+> see [Global Flags](/docs/command-line-usage/global-flags) for additional options
+
+:::info
+
+You need to set environment variables required for provider authentication before starting the MCP server, see [Using a Provider](/docs/getting-started/using-a-provider) for more information.
+
+:::
+
+* * *
+
+### Examples
+
+#### Basic Standalone MCP Server
+
+Launch a standalone MCP server with provider authentication:
+
+```bash
+export GOOGLE_CREDENTIALS=$(cat /path/to/google-credentials.json)
+
+stackql mcp \
+  --mcp.server.type=http \
+  --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9912"}}' \
+  --registry='{"url": "https://registry.stackql.io/providers"}' \
+  --auth='{"google": {"type": "service_account", "credentialsfilepath": "/path/to/google-credentials.json"}}'
+```
+
+#### MCP Server with PostgreSQL Server (In-Memory)
+
+Run both MCP and PostgreSQL servers for dual-protocol access:
+
+```bash
+export GOOGLE_CREDENTIALS=$(cat /path/to/google-credentials.json)
+
+stackql srv \
+  --mcp.server.type=http \
+  --mcp.config '{"server": {"transport": "http", "address": "127.0.0.1:9912"}}' \
+  --pgsrv.port 5665 \
+  --registry='{"url": "https://registry.stackql.io/providers"}' \
+  --auth='{"google": {"type": "service_account", "credentialsfilepath": "/path/to/google-credentials.json"}}'
+```
+
+#### Secure MCP Server with TLS
+
+Launch an MCP server with TLS encryption in reverse proxy mode:
+
+First, generate TLS certificates:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout server_key.pem -out server_cert.pem -days 365 -nodes
+```
+
+Then start the server:
+
+```bash
+stackql srv \
+  --mcp.server.type=reverse_proxy \
+  --mcp.config '{"server": {"tls_cert_file": "server_cert.pem", "tls_key_file": "server_key.pem", "transport": "http", "address": "127.0.0.1:9004"}, "backend": {"dsn": "postgres://stackql:stackql@127.0.0.1:5446?default_query_exec_mode=simple_protocol"}}' \
+  --pgsrv.port 5446 \
+  --registry='{"url": "https://registry.stackql.io/providers"}' \
+  --auth='{"google": {"type": "service_account", "credentialsfilepath": "/path/to/google-credentials.json"}}'
+```
+
+* * *
+
+### Testing Your MCP Server
+
+You can test your MCP server using an MCP client. Here's an example using a command-line MCP client:
+
+```bash
+# List all available tools
+mcp-client exec \
+  --client-type=http \
+  --url=http://127.0.0.1:9912
+
+# Test the greeting tool
+mcp-client exec \
+  --client-type=http \
+  --url=http://127.0.0.1:9912 \
+  --exec.action greet \
+  --exec.args '{"name": "World"}'
+
+# List providers
+mcp-client exec \
+  --client-type=http \
+  --url=http://127.0.0.1:9912 \
+  --exec.action list_providers
+
+# Execute a query
+mcp-client exec \
+  --client-type=http \
+  --url=http://127.0.0.1:9912 \
+  --exec.action query_v2 \
+  --exec.args '{"sql": "SHOW SERVICES IN google"}'
+```
+
+* * *
+
+### Integration with AI Assistants
+
+To integrate StackQL's MCP server with AI assistants like Claude Desktop, add the following to your MCP configuration file:
+
+**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "stackql": {
+      "command": "stackql",
+      "args": [
+        "mcp",
+        "--mcp.server.type=http",
+        "--mcp.config",
+        "{\"server\": {\"transport\": \"http\", \"address\": \"127.0.0.1:9912\"}}"
+      ]
+    }
+  }
+}
+```
+
+:::note
+
+Configuration file locations vary by operating system and AI assistant. Consult your AI assistant's documentation for the correct configuration file path and format.
+
+:::
+
+* * *
+
+### Architecture Considerations
+
+When choosing a deployment mode, consider:
+
+1. **Standalone (`mcp` command)**: Simplest setup, ideal for development and testing
+2. **In-Memory (`srv` with `http` type)**: Best performance, single process, suitable for most production use cases
+3. **Reverse Proxy (`srv` with `reverse_proxy` type)**:
+   - Enables workload separation across processes or hosts
+   - Supports TLS encryption for secure MCP endpoints
+   - Allows independent scaling of MCP and PostgreSQL interfaces
+   - Provides flexibility for enterprise CA integration (note: enterprise CA support is experimental)
+
+:::caution
+
+When using TLS with enterprise Certificate Authorities (CAs), additional configuration may be required. This functionality is experimental and may require adjustments based on your specific CA implementation.
+
+:::

--- a/docs/command-line-usage/srv.md
+++ b/docs/command-line-usage/srv.md
@@ -11,7 +11,7 @@ description: Query and Deploy Cloud Infrastructure and Resources using SQL
 image: "/img/stackql-featured-image.png"
 ---
 
-Command used to launch StackQL as a service, which can then be accessed by clients using [Postgres wire protocol](https://www.postgresql.org/docs/current/protocol.html) clients authenticated using mTLS.
+Command used to launch StackQL as a service, which can then be accessed by clients using [Postgres wire protocol](https://www.postgresql.org/docs/current/protocol.html) clients authenticated using mTLS. The `srv` command can also run a [Model Context Protocol (MCP)](/docs/command-line-usage/mcp) server alongside the PostgreSQL wire protocol server, enabling dual-protocol access for both traditional database clients and AI agents.
 
 * * * 
 
@@ -35,9 +35,24 @@ Although the StackQL server uses the Postgres wire protocol, it is not a Postgre
 |<span class="nowrap">`--pgsrv.port`</span>|Port the server is listening on (e.g. `5444`)|
 |<span class="nowrap">`--pgsrv.tls`</span>|mTLS configuration object, see the [example](#examples) below|
 |<span class="nowrap">`--pgsrv.loglevel`</span>|Log level (default `WARN`)|
-&nbsp;  
-&nbsp;  
+&nbsp;
+&nbsp;
 > see [Global Flags](/docs/command-line-usage/global-flags) for additional options
+
+### MCP Server Options
+
+When running the `srv` command with MCP support, the following additional options are available:
+
+| Option | Description |
+|--|--|
+|<span class="nowrap">`--mcp.server.type`</span>|MCP server type: `http` (in-memory) or `reverse_proxy` (TCP-based)|
+|<span class="nowrap">`--mcp.config`</span>|JSON configuration object for the MCP server (see [MCP documentation](/docs/command-line-usage/mcp))|
+
+:::tip
+
+See the [MCP command documentation](/docs/command-line-usage/mcp) for detailed information on configuring and using the MCP server, including deployment modes, configuration options, and integration with AI assistants.
+
+:::
 
 :::info
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -36,6 +36,7 @@ const sidebars = {
         'command-line-usage/exec',
         'command-line-usage/shell',
         'command-line-usage/srv',
+        'command-line-usage/mcp',
         'command-line-usage/registry',
         'command-line-usage/global-flags',
       ]


### PR DESCRIPTION
- Created new mcp.md documentation covering all three deployment modes (standalone, in-memory dual-protocol, and reverse proxy with TLS)
- Documented available MCP tools (greet, list_providers, list_services, list_resources, list_methods, query_v2)
- Added configuration options and examples for each deployment scenario
- Updated srv.md to reference MCP capabilities and link to MCP docs
- Updated sidebars.js to include MCP documentation in navigation
- Included integration examples for AI assistants like Claude Desktop